### PR TITLE
Look at 4 controller slots before giving up

### DIFF
--- a/Hooks_XInput.h
+++ b/Hooks_XInput.h
@@ -80,7 +80,15 @@ public:
 	inline XINPUT_STATE GetPadState()
 	{
 		XINPUT_STATE pState = {0};
-		HRESULT hr = XInputGetState_RealFunc(0,&pState);
+		HRESULT hr;
+
+		// Look at 4 controller slots before giving up
+		for (int i = 0; i < 4; i++)
+		{
+			hr = XInputGetState_RealFunc(i, &pState);
+			if (hr == ERROR_SUCCESS) { break; }
+		}
+
 		if(hr != ERROR_SUCCESS) { Log::VerboseDebug("gPadBuffer::GetPadState()::HRESULT %d", hr); }
 		return pState;
 	}


### PR DESCRIPTION
While testing event processing, I noticed that steam set my controller to index 1 instead of 0, resulting in a 1167 HRESULT.

I wasn't sure if you would prefer to log every failure, or just if there is a failure after all 4 indices have been exhausted.